### PR TITLE
Start on worker and iframe management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.8",
       "license": "MIT",
       "dependencies": {
+        "@rollup/browser": "^4.39.0",
         "@vizhub/viz-types": "^0.1.0",
         "@vizhub/viz-utils": "^0.1.0",
         "magic-sandbox": "^2.2.0",
@@ -811,6 +812,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@rollup/browser": {
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@rollup/browser/-/browser-4.39.0.tgz",
+      "integrity": "sha512-B+TTtDFcj7G4qc/wWrs80x8VLsfK1tOBQ62oSdnsU0T+pyXUUAF12dg87JNLgYS3cBGkX1isv2eePG9BB8nM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.7"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.39.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.39.0.tgz",
@@ -1102,7 +1112,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsdom": {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
     "vitest": "^3.1.1"
   },
   "dependencies": {
-    "sucrase": "^3.35.0",
+    "@rollup/browser": "^4.39.0",
     "@vizhub/viz-types": "^0.1.0",
     "@vizhub/viz-utils": "^0.1.0",
-    "magic-sandbox": "^2.2.0"
+    "magic-sandbox": "^2.2.0",
+    "sucrase": "^3.35.0"
   }
 }

--- a/src/buildHTML.ts
+++ b/src/buildHTML.ts
@@ -33,8 +33,14 @@ export const buildHTML = async ({
   // Only required for v3 runtime
   // For v3, EITHER files OR vizCache is required
   vizCache?: VizCache;
+
+  // Only required for v3 runtime
   vizId?: string;
+
+  // Only required for v3 runtime
   slugCache?: SlugCache;
+
+  // Only required for v3 runtime
   getSvelteCompiler?: () => Promise<SvelteCompiler>;
 }): Promise<string> => {
   if (!files && !vizCache) {

--- a/src/createRuntime.ts
+++ b/src/createRuntime.ts
@@ -1,0 +1,65 @@
+import { VizContent } from "@vizhub/viz-types";
+import { vizContentToFileCollection } from "./utils/vizContentToFileCollection";
+
+// Flag for debugging.
+const debug = false;
+
+export type VizHubRuntime = {
+  // Resets the iframe srcdoc when code changes.
+  handleCodeChange: (content: VizContent) => void;
+  // Cleans up the event listener from the Worker.
+  cleanup: () => void;
+};
+
+export const createRuntime = ({
+  iframe,
+  setBuildErrorMessage,
+  worker,
+}: {
+  iframe: HTMLIFrameElement;
+  setBuildErrorMessage: (error: string | null) => void;
+  worker: Worker;
+}): VizHubRuntime => {
+  // This runs when the build worker sends a message.
+  const listener: (e: MessageEvent) => void = ({
+    data,
+  }) => {
+    if (data.type === "buildHTMLResponse") {
+      const html: string | undefined = data.html;
+      const error: Error | undefined = data.error;
+
+      if (error) {
+        setBuildErrorMessage(error.message);
+      } else {
+        setBuildErrorMessage(null);
+
+        // Reset the srcdoc
+        if (html) {
+          iframe.srcdoc = html;
+        }
+      }
+    }
+  };
+  worker.addEventListener("message", listener);
+  const cleanup = () => {
+    worker.removeEventListener("message", listener);
+  };
+
+  const handleCodeChange = (content: VizContent) => {
+    if (debug) {
+      console.log("[v2 runtime] handleCodeChange");
+    }
+
+    // Simply reset the srcdoc when code changes
+    const message = {
+      type: "buildHTMLRequest",
+      files: vizContentToFileCollection(content),
+    };
+    worker.postMessage(message);
+  };
+
+  return {
+    handleCodeChange,
+    cleanup,
+  };
+};

--- a/src/old-implementation-reference/setupV3Runtime.ts
+++ b/src/old-implementation-reference/setupV3Runtime.ts
@@ -1,0 +1,482 @@
+// @ts-ignore
+import Worker from './worker.ts?worker';
+
+import {
+  ResolvedVizFileId,
+  V3BuildResult,
+  V3WindowMessage,
+  V3WorkerMessage,
+} from './types';
+import { getFileText } from 'entities';
+import {
+  parseId,
+  cleanRollupErrorMessage,
+} from '@vizhub/runtime';
+import { cleanRollupErrorMessage } from './cleanRollupErrorMessage';
+import { VizContent, VizId } from '@vizhub/viz-types';
+
+// Flag for debugging.
+const debug = false;
+
+// Nothing happening.
+const IDLE = 'IDLE';
+
+// An update has been enqueued
+// via requestAnimationFrame.
+const ENQUEUED = 'ENQUEUED';
+
+// An update (build and run) is pending,
+// and the files have not changed.
+const PENDING_CLEAN = 'PENDING_CLEAN';
+
+// An update (build and run) is pending,
+// and the files have changed
+// while this run is taking place.
+const PENDING_DIRTY = 'PENDING_DIRTY';
+
+export type V3Runtime = {
+  // Performs a hot reload of a new build.
+  handleCodeChange: (content: VizContent) => void;
+
+  // Performs a hot reload of a new build.
+  invalidateVizCache: (changedVizIds: Array<VizId>) => void;
+
+  // Performs a hard reset of the srcdoc and
+  // entire runtime environment.
+  resetSrcdoc: (changedVizIds: Array<VizId>) => void;
+};
+
+export const setupV3Runtime = ({
+  vizId,
+  iframe,
+  setSrcdocErrorMessage,
+  getLatestContent,
+  resolveSlugKey,
+  writeFile,
+}: {
+  vizId: VizId;
+  iframe: HTMLIFrameElement;
+  setSrcdocErrorMessage: (error: string | null) => void;
+  getLatestContent: (vizId: VizId) => Promise<VizContent>;
+  resolveSlugKey: (slugKey: string) => Promise<VizId>;
+  writeFile: (fileName: string, content: string) => void;
+}): V3Runtime => {
+  // The "build worker", a Web Worker that does the building.
+  const worker = new Worker();
+
+  // Valid State Transitions:
+  //
+  //  * IDLE --> ENQUEUED
+  //    When the system is idle and files are changed.
+  //
+  //  * ENQUEUED --> PENDING_CLEAN
+  //    When the pending changes run.
+  //
+  //  * PENDING_CLEAN --> IDLE
+  //    When the pending update finishes running
+  //    and files were not changed in the mean time.
+  //
+  //  * PENDING_CLEAN --> PENDING_DIRTY
+  //    When files are changed while an update is pending.
+  //
+  //  * PENDING_DIRTY --> ENQUEUED
+  //    When the pending update finishes running
+  //    and files were changed in the mean time.
+  //
+  // When a build error happens, the state is set to IDLE.
+  // This is to prevent a build error from causing
+  // the whole system to stop working.
+  //
+  // Valid State Transitions (with build errors):
+  // TODO complete this section
+
+  let state:
+    | typeof IDLE
+    | typeof ENQUEUED
+    | typeof PENDING_CLEAN
+    | typeof PENDING_DIRTY = IDLE;
+
+  if (debug) {
+    setInterval(() => {
+      console.log('state', state);
+    }, 1000);
+  }
+
+  // Pending promise resolvers.
+  let pendingBuildPromise:
+    | ((buildResult?: V3BuildResult) => void)
+    | null = null;
+  let pendingRunPromise: (() => void) | null = null;
+
+  // Logic around profiling build times.
+  const profileBuildTimes = debug;
+  let buildTimes: Array<number> = [];
+  const avg = (arr: Array<number>) =>
+    arr.reduce((a, b) => a + b, 0) / arr.length;
+  const n = 100;
+
+  // This runs when the build worker sends a message.
+  worker.addEventListener('message', async ({ data }) => {
+    const message: V3WorkerMessage =
+      data as V3WorkerMessage;
+
+    // Handle 'buildResponse' messages.
+    // These are sent by the build worker in response
+    // to a 'buildRequest' message.
+    if (message.type === 'buildResponse') {
+      const buildResult: V3BuildResult | undefined =
+        message.buildResult;
+      const error: Error | undefined = message.error;
+
+      if (profileBuildTimes && buildResult) {
+        buildTimes.push(buildResult.time);
+        // Every n times, log the rolling average.
+        if (buildTimes.length % n === 0) {
+          console.log(
+            'Average build time: ' +
+              avg(buildTimes) +
+              ' ms',
+          );
+          buildTimes = [];
+        }
+      }
+
+      // Regardless of whether the build succeeded or failed,
+      // resolve the pending build promise,
+      // so that the system remains responsive.
+      if (pendingBuildPromise) {
+        pendingBuildPromise(buildResult);
+        pendingBuildPromise = null;
+      }
+
+      if (error) {
+        setSrcdocErrorMessage(
+          cleanRollupErrorMessage({
+            rawMessage: error.message,
+            vizId,
+          }),
+        );
+      }
+    }
+
+    // Handle 'contentRequest' messages.
+    // These are sent by the worker when it needs
+    // to get the content of a file, in order to
+    // populate its VizCache.
+    if (message.type === 'contentRequest') {
+      const { vizId } = message;
+
+      const content = await getLatestContent(vizId);
+
+      const contentResponseMessage: V3WorkerMessage = {
+        type: 'contentResponse',
+        vizId: message.vizId,
+        content,
+      };
+
+      if (debug) {
+        console.log(
+          '[v3 runtime] received contentRequest, sending contentResponse',
+          contentResponseMessage,
+        );
+      }
+
+      // Send the content back to the worker.
+      worker.postMessage(contentResponseMessage);
+    }
+
+    // Handle 'resolveSlugRequest' messages.
+    // These are sent by the worker when it needs
+    // to resolve a slug import to a viz ID.
+    if (message.type === 'resolveSlugRequest') {
+      const { slugKey } = message;
+
+      const resolveSlugResponseMessage: V3WorkerMessage = {
+        type: 'resolveSlugResponse',
+        slugKey,
+        requestId: message.requestId,
+        vizId: await resolveSlugKey(slugKey),
+      };
+
+      if (debug) {
+        console.log(
+          '[v3 runtime] received resolveSlugRequest, sending resolveSlugResponse',
+          resolveSlugResponseMessage,
+        );
+      }
+      // Send the viz ID back to the worker.
+      worker.postMessage(resolveSlugResponseMessage);
+    }
+
+    // Handle 'invalidateVizCacheResponse' messages.
+    // These are sent by the worker in response to
+    // an 'invalidateVizCacheRequest' message.
+    if (message.type === 'invalidateVizCacheResponse') {
+      if (debug) {
+        console.log(
+          '[v3 runtime] received invalidateVizCacheResponse',
+          message,
+        );
+      }
+      // Leverage existing infra for executing the hot reloading.
+      handleCodeChange();
+    }
+
+    if (message.type === 'resetSrcdocResponse') {
+      const srcdoc: string | undefined = message.srcdoc;
+      const error: Error | undefined = message.error;
+
+      if (error) {
+        setSrcdocErrorMessage(
+          cleanRollupErrorMessage({
+            rawMessage: error.message,
+            vizId,
+          }),
+        );
+      } else {
+        setSrcdocErrorMessage(null);
+
+        // Really reset the srcdoc!
+        // console.log('Really reset the srcdoc!');
+        if (srcdoc) {
+          iframe.srcdoc = srcdoc;
+        }
+      }
+    }
+  });
+
+  // This runs when the IFrame sends a message.
+  window.addEventListener('message', ({ data }) => {
+    // Handle 'runDone' and 'runError' messages.
+    // These happen in response to sending a 'runJS' message.
+    if (
+      data.type === 'runDone' ||
+      data.type === 'runError'
+    ) {
+      // console.log('got ' + data.type);
+      if (pendingRunPromise) {
+        // TODO pass errors out for display
+        // pendingRunPromise(data as V3WindowMessage);
+        pendingRunPromise();
+        pendingRunPromise = null;
+      }
+    }
+    if (data.type === 'runError') {
+      setSrcdocErrorMessage(data.error.message);
+    }
+    if (data.type === 'writeFile') {
+      if (data.fileName && data.content) {
+        writeFile(data.fileName, data.content);
+      }
+    }
+  });
+
+  const handleCodeChange = () => {
+    if (state === IDLE) {
+      state = ENQUEUED;
+      update();
+    } else if (state === PENDING_CLEAN) {
+      state = PENDING_DIRTY;
+    }
+  };
+
+  // This runs when one or more imported vizzes are changed.
+  const invalidateVizCache = (
+    changedVizIds: Array<VizId>,
+  ): void => {
+    // Send a message to the worker to invalidate the cache.
+    const message: V3WorkerMessage = {
+      type: 'invalidateVizCacheRequest',
+      changedVizIds,
+    };
+    worker.postMessage(message);
+  };
+
+  const profileHotReloadFPS = true;
+  let updateCount = 0;
+  if (profileHotReloadFPS) {
+    setInterval(() => {
+      if (debug && updateCount > 0) {
+        console.log(
+          updateCount +
+            ' hot reload' +
+            (updateCount !== 1 ? 's' : '') +
+            ' in the last second',
+        );
+      }
+      updateCount = 0;
+    }, 1000);
+  }
+
+  const build = () => {
+    return new Promise<V3BuildResult | undefined>(
+      (resolve) => {
+        pendingBuildPromise = resolve;
+        const message: V3WorkerMessage = {
+          type: 'buildRequest',
+          vizId,
+          enableSourcemap: true,
+        };
+        worker.postMessage(message);
+      },
+    );
+  };
+
+  // Builds and runs the latest files.
+  const update = async () => {
+    state = PENDING_CLEAN;
+    if (debug) {
+      console.log('update: before run');
+    }
+
+    // Build the code. This may fail and return `undefined`.
+    const buildResult: V3BuildResult | undefined =
+      await build();
+
+    // If the build was successful, run the code.
+    if (buildResult !== undefined) {
+      await run(buildResult);
+    }
+
+    if (debug) {
+      console.log('update: after run');
+    }
+    updateCount++;
+    // TypeScript can't comprehend that `state`
+    // may change during the await calls above.
+    // @ts-ignore
+    if (state === PENDING_DIRTY) {
+      requestAnimationFrame(update);
+      state = ENQUEUED;
+    } else {
+      state = IDLE;
+    }
+  };
+
+  let previousCSSFiles: Array<ResolvedVizFileId> = [];
+  const run = (buildResult: V3BuildResult) => {
+    return new Promise<void>((resolve) => {
+      const { src, warnings, cssFiles } = buildResult;
+
+      // Sanity check.
+      // At this point, since there were no errors,
+      // we expect there to be a `src` property.
+      // This should never happen, but log & error just in case!
+      if (src === undefined) {
+        if (debug) {
+          console.log(
+            '[v3 runtime] src is undefined, but no errors!',
+          );
+        }
+        throw new Error(
+          '[v3 runtime] src is undefined, but no errors!',
+        );
+      }
+
+      // Set pendingRunPromise because at this point,
+      // we expect an asynchronous response when the run is done.
+      // The iframe should send either a `runDone` or `runError` message.
+      pendingRunPromise = resolve;
+
+      // Handle build warnings
+      if (warnings.length > 0) {
+        // TODO: Distinguish between warnings and errors in UI
+        setSrcdocErrorMessage(
+          warnings
+            .map((warning) => warning.message)
+            .join('\n\n'),
+        );
+      } else {
+        setSrcdocErrorMessage(null); // Clear error message if no warnings
+      }
+
+      if (iframe.contentWindow) {
+        // For each cssFiles
+        for (const cssFile of cssFiles) {
+          const { vizId, fileName } = parseId(cssFile);
+
+          getLatestContent(vizId).then((content) => {
+            const src = getFileText(content, fileName);
+
+            if (src === null) {
+              // The file doesn't exist.
+              // TODO surface this error to the user
+              // in a nicer way than this.
+              console.warn(
+                `Imported CSS file ${fileName} doesn't exist.`,
+              );
+              return;
+            }
+
+            // TODO only inject CSS if it has changed.
+            const runCSSMessage: V3WindowMessage = {
+              type: 'runCSS',
+              id: cssFile,
+              src,
+            };
+
+            if (debug) {
+              console.log('runCSSMessage', runCSSMessage);
+            }
+
+            iframe.contentWindow?.postMessage(
+              runCSSMessage,
+              window.location.origin,
+            );
+          });
+        }
+
+        // Detect which CSS files have been removed
+        // and remove them from the iframe.
+        const removedCSSFiles = previousCSSFiles.filter(
+          (id) => !cssFiles.includes(id),
+        );
+        previousCSSFiles = cssFiles;
+        if (debug) {
+          console.log('removedCSSFiles', removedCSSFiles);
+        }
+        for (const id of removedCSSFiles) {
+          const removeCSSMessage: V3WindowMessage = {
+            type: 'runCSS',
+            id,
+            src: '',
+          };
+          iframe.contentWindow?.postMessage(
+            removeCSSMessage,
+            window.location.origin,
+          );
+        }
+
+        // Clear the console before each run.
+        console.clear();
+
+        const runJSMessage: V3WindowMessage = {
+          type: 'runJS',
+          src,
+        };
+        iframe.contentWindow.postMessage(
+          runJSMessage,
+          window.location.origin,
+        );
+      }
+    });
+  };
+
+  const resetSrcdoc = (changedVizIds: Array<VizId>) => {
+    state = IDLE;
+    pendingBuildPromise = null;
+    pendingRunPromise = null;
+    const message: V3WorkerMessage = {
+      type: 'resetSrcdocRequest',
+      vizId,
+      changedVizIds,
+    };
+    worker.postMessage(message);
+  };
+
+  return {
+    handleCodeChange,
+    invalidateVizCache,
+    resetSrcdoc,
+  };
+};

--- a/src/old-implementation-reference/types.ts
+++ b/src/old-implementation-reference/types.ts
@@ -1,0 +1,159 @@
+import { VizContent, VizId } from '@vizhub/viz-types';
+import { V3PackageJson } from 'entities';
+
+// The result of a build.
+export type V3BuildResult = {
+  // Could be undefined if there's no index.js.
+  src: string | undefined;
+  pkg: V3PackageJson | undefined;
+  warnings: Array<V3BuildError>;
+  time: number;
+
+  // A list of CSS files to be injected into the IFrame.
+  // e.g. `['./styles.css']`
+  // TODO e.g. `['@curran/scatter-plot/styles.css']`
+  cssFiles: Array<ResolvedVizFileId>;
+};
+
+// The shape of a build error.
+export type V3BuildError = {
+  code: string;
+  message: string;
+};
+
+// A resolved viz file id is of the form
+// `{idOrSlug}/{fileName}`
+export type ResolvedVizFileId = string;
+
+// Messages sent to and from the build worker.
+export type V3WorkerMessage =
+  // `contentRequest`
+  //  * Sent from the worker to the main thread.
+  //  * When the worker requests the content of an imported viz.
+  //  * The main thread should respond with a `getContentResponse` message.
+  //  * This supports the worker's VizCache when it has a cache miss.
+  | { type: 'contentRequest'; vizId: VizId }
+
+  // `contentResponse`
+  //  * Sent from the main thread to the worker.
+  //  * When the main thread responds to a `contentRequest` message.
+  | {
+      type: 'contentResponse';
+      vizId: VizId;
+      content: VizContent;
+    }
+
+  // `buildRequest`
+  //  * Sent from the main thread to the worker.
+  //  * When the main thread requests a build.
+  | {
+      type: 'buildRequest';
+      vizId: VizId;
+      enableSourcemap: boolean;
+    }
+
+  // `buildResponse`
+  //  * Sent from the worker to the main thread.
+  //  * When the worker responds to a `buildRequest` message.
+  //  * This message is sent to the main thread.
+  //  * This message includes
+  //  * EITHER `buildResult` the result of the build
+  //  * OR `error` if the build failed.
+  | {
+      type: 'buildResponse';
+      buildResult?: V3BuildResult;
+      error?: Error;
+    }
+
+  // `invalidateVizCache`
+  //  * Sent from the main thread to the worker.
+  //  * When the main thread wants to invalidate the VizCache.
+  //  * This happens when an imported viz changes.
+  | {
+      type: 'invalidateVizCacheRequest';
+      changedVizIds: Array<VizId>;
+    }
+
+  // `invalidateVizCacheResponse`
+  //  * Sent from the worker to the main thread.
+  //  * When the worker responds to a `invalidateVizCacheRequest` message.
+  | {
+      type: 'invalidateVizCacheResponse';
+    }
+
+  // `resolveSlugRequest`
+  //  * Sent from the worker to the main thread.
+  //  * When the worker requests a viz ID for a slug.
+  | {
+      type: 'resolveSlugRequest';
+      slugKey: string;
+      requestId: string;
+    }
+
+  // `resolveSlugResponse`
+  //  * Sent from the main thread to the worker.
+  //  * When the main thread responds to a `resolveSlugRequest` message.
+  | {
+      type: 'resolveSlugResponse';
+      slugKey: string;
+      vizId: VizId;
+      requestId: string;
+    }
+
+  // `resetRequest`
+  //  * Sent from the main thread to the worker.
+  //  * When the main thread wants to reset the runtime
+  //  * This happens when an error occurs.
+  | {
+      type: 'resetSrcdocRequest';
+      vizId: VizId;
+      changedVizIds: Array<VizId>;
+    }
+
+  // `resetResponse`
+  //  * Sent from the worker to the main thread.
+  //  * When the worker responds to a `resetRequest` message.
+  //  * Provides:
+  //  * EITHER a fresh `srcdoc` for the iframe
+  //  * OR an `error` if the build failed.
+  | {
+      type: 'resetSrcdocResponse';
+      srcdoc?: string;
+      error?: Error;
+    };
+
+// Messages sent to and from the IFrame window.
+export type V3WindowMessage =
+  // `runJS`
+  //  * Sent from the main thread to the IFrame.
+  //  * Triggers hot reloading within the V3 runtime.
+  | {
+      type: 'runJS';
+      src: string;
+    }
+
+  // `runCSS`
+  //  * Sent from the main thread to the IFrame.
+  //  * Triggers hot reloading of CSS within the V3 runtime.
+  | {
+      type: 'runCSS';
+      src: string;
+      id: ResolvedVizFileId;
+    }
+
+  // `runDone`
+  //  * Sent from the IFrame to the main thread.
+  //  * Indicates that the V3 runtime has finished running the JS.
+  //  * If this was sent, there were no immediate runtime errors.
+  | {
+      type: 'runDone';
+    }
+
+  // `runError`
+  //  * Sent from the IFrame to the main thread.
+  //  * Indicates that the V3 runtime has finished running the JS.
+  //  * If this was sent, there was an immediate runtime error.
+  | {
+      type: 'runError';
+      error: Error;
+    };

--- a/src/old-implementation-reference/worker.ts
+++ b/src/old-implementation-reference/worker.ts
@@ -1,0 +1,237 @@
+import { rollup } from '@rollup/browser';
+import {
+  VizCache,
+  buildHTML,
+  createVizCache,
+  createSlugCache,
+  svelteCompilerUrl,
+} from '@vizhub/runtime';
+import { V3BuildResult, V3WorkerMessage } from './types';
+import { VizContent, VizId } from '@vizhub/viz-types';
+
+const debug = false;
+
+// Generate a unique request ID
+const generateRequestId = (): string =>
+  (Math.random() + '').slice(2);
+
+// Tracks pending promises for 'contentResponse' messages
+const pendingContentResponsePromises = new Map();
+
+// Tracks pending promises for 'resolveSlugResponse' messages
+const pendingResolveSlugResponsePromises = new Map();
+
+// Create a viz cache that's backed by the main thread
+let vizCache: VizCache = createVizCache({
+  initialContents: [],
+  handleCacheMiss: async (
+    vizId: VizId,
+  ): Promise<VizContent> => {
+    const message: V3WorkerMessage = {
+      type: 'contentRequest',
+      vizId,
+    };
+
+    if (debug) {
+      console.log(
+        '[build worker] sending content request message to main thread',
+        message,
+      );
+    }
+    postMessage(message);
+
+    return new Promise((resolve) => {
+      pendingContentResponsePromises.set(vizId, resolve);
+    });
+  },
+});
+
+// Create a slug cache that's backed by the main thread
+const slugCache = createSlugCache({
+  initialMappings: {},
+  handleCacheMiss: async (slug) => {
+    const requestId = generateRequestId();
+    const message: V3WorkerMessage = {
+      type: 'resolveSlugRequest',
+      slugKey: slug,
+      requestId,
+    };
+
+    if (debug) {
+      console.log(
+        '[build worker] sending resolve slug request message to main thread',
+        message,
+      );
+    }
+    postMessage(message);
+
+    return new Promise((resolve) => {
+      pendingResolveSlugResponsePromises.set(
+        requestId,
+        resolve,
+      );
+    });
+  },
+});
+
+// Inspired by
+// https://github.com/sveltejs/sites/blob/master/packages/repl/src/lib/workers/bundler/index.js#L44
+// unpkg doesn't set the correct MIME type for .cjs files
+// https://github.com/mjackson/unpkg/issues/355
+const getSvelteCompiler = async () => {
+  const compiler = await fetch(svelteCompilerUrl).then(
+    (r) => r.text(),
+  );
+  (0, eval)(compiler);
+
+  // console.log(self.svelte);
+  // @ts-ignore
+  return self.svelte.compile;
+};
+
+// Handle messages from the main thread
+addEventListener('message', async ({ data }) => {
+  const message: V3WorkerMessage = data as V3WorkerMessage;
+
+  switch (message.type) {
+    case 'buildRequest': {
+      const { vizId, enableSourcemap } = message;
+
+      if (debug) {
+        console.log(
+          '[build worker] received build request message from main thread',
+          message,
+        );
+      }
+
+      let error: Error | undefined;
+      let buildResultHTML: string;
+      try {
+        buildResultHTML = await buildHTML({
+          vizId,
+          enableSourcemap,
+          rollup,
+          vizCache,
+          slugCache,
+          getSvelteCompiler,
+        });
+      } catch (e) {
+        if (debug) console.error(e);
+        error = e;
+      }
+
+      //
+      const buildResult: V3BuildResult = {
+        src: buildResultHTML,
+        warnings: [],
+        pkg: undefined,
+        time: 0,
+        cssFiles: [],
+      };
+
+      // Post the result of the build process
+      const responseMessage: V3WorkerMessage = {
+        type: 'buildResponse',
+        buildResult,
+        error,
+      };
+      postMessage(responseMessage);
+      break;
+    }
+
+    case 'contentResponse': {
+      // Resolve pending promises for content snapshots
+      const resolver = pendingContentResponsePromises.get(
+        message.vizId,
+      );
+      if (resolver) {
+        resolver(message.content);
+        pendingContentResponsePromises.delete(
+          message.vizId,
+        );
+      }
+      break;
+    }
+
+    case 'invalidateVizCacheRequest': {
+      if (debug) {
+        console.log(
+          '[build worker] received invalidateVizCacheRequest',
+          message,
+        );
+      }
+      const { changedVizIds } = message;
+
+      // Invalidate the viz cache for the changed vizzes.
+      // This will cause the worker to re-fetch the content
+      // of those vizzes the next time it needs them.
+      for (const vizId of changedVizIds) {
+        vizCache.invalidate(vizId);
+      }
+
+      const responseMessage: V3WorkerMessage = {
+        type: 'invalidateVizCacheResponse',
+      };
+      postMessage(responseMessage);
+      break;
+    }
+
+    // Resolve pending promises for slug resolution
+    case 'resolveSlugResponse': {
+      const resolver =
+        pendingResolveSlugResponsePromises.get(
+          message.requestId,
+        );
+      if (resolver) {
+        resolver(message.vizId);
+        pendingResolveSlugResponsePromises.delete(
+          message.requestId,
+        );
+      }
+      break;
+    }
+
+    case 'resetSrcdocRequest': {
+      // Invalidate viz cache for changed vizzes.
+      const { vizId, changedVizIds } = message;
+      for (const changedVizId of changedVizIds) {
+        vizCache.invalidate(changedVizId);
+      }
+
+      // Compute a fresh build/
+      let error: Error | undefined;
+      let buildResult: V3BuildResult | undefined;
+      try {
+        buildResult = await buildHTML({
+          vizId,
+          enableSourcemap: true,
+          rollup,
+          vizCache,
+          slugCache,
+          getSvelteCompiler,
+        });
+      } catch (e) {
+        if (debug) console.error(e);
+        error = e;
+      }
+
+      let srcdoc: string | undefined;
+      if (buildResult !== undefined) {
+        srcdoc = await computeSrcDocV3({
+          vizCache,
+          buildResult,
+        });
+      }
+
+      // Post the result of the build process
+      const responseMessage: V3WorkerMessage = {
+        type: 'resetSrcdocResponse',
+        srcdoc,
+        error,
+      };
+      postMessage(responseMessage);
+
+      break;
+    }
+  }
+});

--- a/src/test/testInBrowser.ts
+++ b/src/test/testInBrowser.ts
@@ -2,10 +2,13 @@ import { Browser, Page } from "puppeteer";
 import { rollup } from "rollup";
 import { expect } from "vitest";
 import { buildHTML } from "../index";
-import { VizCache } from "../v3/vizCache";
-import { FileCollection, VizId } from "@vizhub/viz-types";
-import { SlugCache } from "../v3/slugCache";
-import { SvelteCompiler } from "../v3/transformSvelte";
+import type { VizCache } from "../v3/vizCache";
+import type {
+  FileCollection,
+  VizId,
+} from "@vizhub/viz-types";
+import type { SlugCache } from "../v3/slugCache";
+import type { SvelteCompiler } from "../v3/transformSvelte";
 
 const DEBUG = false;
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,65 @@
+import { buildHTML } from "./buildHTML";
+import { rollup } from "@rollup/browser";
+import type { RollupBuild, RollupOptions } from "rollup";
+import { svelteCompilerUrl } from "./v3/transformSvelte";
+import { FileCollection } from "@vizhub/viz-types";
+
+// Flag for debugging
+const debug = false;
+
+// Inspired by
+// https://github.com/sveltejs/sites/blob/master/packages/repl/src/lib/workers/bundler/index.js#L44
+// unpkg doesn't set the correct MIME type for .cjs files
+// https://github.com/mjackson/unpkg/issues/355
+// TODO try it from jsdelivr without using `eval`
+const getSvelteCompiler = async () => {
+  const compiler = await fetch(svelteCompilerUrl).then(
+    (r) => r.text(),
+  );
+  (0, eval)(compiler);
+
+  // console.log(self.svelte);
+  // @ts-ignore
+  return self.svelte.compile;
+};
+
+// Handle messages from the main thread
+addEventListener("message", async (event) => {
+  const { data } = event;
+
+  if (debug) {
+    console.log("[worker] received message:", data);
+  }
+
+  if (data.type === "buildHTMLRequest") {
+    const files: FileCollection = data.files;
+
+    try {
+      // Build HTML from the files
+      const html = await buildHTML({
+        files,
+        // TypeScript is stupid
+        rollup: rollup as (
+          options: RollupOptions,
+        ) => Promise<RollupBuild>,
+        getSvelteCompiler,
+      });
+
+      // Send the built HTML back to the main thread
+      postMessage({
+        type: "buildHTMLResponse",
+        html,
+      });
+    } catch (error) {
+      if (debug) {
+        console.error("[worker] build error:", error);
+      }
+
+      // Send the error back to the main thread
+      postMessage({
+        type: "buildHTMLResponse",
+        error,
+      });
+    }
+  }
+});


### PR DESCRIPTION
This set of changes will really "complete" the idea of the VizHub Runtime package - a runtime environment not just a build tool. The idea is to introduce a mechanism to manage an `iframe` passed in from the outside, and provide a function to call to update the source code, which will use a Web Worker to compute a new build and, in the case of the V3 Runtime, hot reload it (JS and CSS changes), and in the case of the other versions reset the `srcdoc` of the `iframe.

Progression

 * [ ] Scaffold first pass iframe management logic
 * [ ] Scaffold first pass Web Worker logic
 * [ ] Develop a testing system that actually tests the Web Worker build in Puppeteer
 * [ ] Develop a testing system that actually tests the iframe manager + Web Worker build in Puppeteer
 * [ ] Develop tests for the V2 runtime (simple case of resetting srcdoc)
 * [ ] Develop tests for the V3 runtime (initial srcdoc, but also hot reloading of JS and CSS)
 * [ ] Verify the distribution integrates well with downstream VizHub app
 * [ ] Verify that the large build including `@rollup/browser` is _only_ fetched in the Web Worker and not the main VizHub app bundle